### PR TITLE
Do not set autocomplete=off on textarea element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Autocomplete",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "authors": [
     "Ben Tedder <ben.tedder@lonelyplanet.com>",
     "WunderBart <hello@wunderbart.com>"

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -85,7 +85,10 @@ define([ "jquery" ], function($) {
           .html(this.config.templates.empty)
     };
 
-    this.$el = $(this.config.el).attr("autocomplete", "off"), // turn off native browser autocomplete feature
+    this.$el = $(this.config.el);
+
+    // turn off native browser autocomplete feature unless it's textarea
+    !this.$el.is("textarea") && this.$el.attr("autocomplete", "off");
 
     this.init();
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Autocomplete",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "An autocomplete widget",
   "repository": {
     "type": "git",

--- a/spec/tests/autocomplete_spec.js
+++ b/spec/tests/autocomplete_spec.js
@@ -44,8 +44,18 @@ require([ "jquery", "autocomplete" ], function($, AutoComplete) {
     describe("The DOM element", function() {
 
       it("should exist.", function() {
-        var el = $(instance.config.el);
-        expect(el).toExist();
+        expect(instance.$el).toExist();
+      });
+
+      it("should have autocomplete='off' attribute", function() {
+        expect(instance.$el).toHaveAttr("autocomplete", "off");
+      });
+
+      it("should't have autocomplete attribute if $el is textarea", function() {
+        setFixtures("<textarea class='js-autocomplete'></textarea>");
+        var instanceOnTextarea = new AutoComplete({ el: ".js-autocomplete" });
+
+        expect(instanceOnTextarea.$el).not.toHaveAttr("autocomplete");
       });
 
       it("should be wrapped in a div with the passed ID.", function() {

--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -85,9 +85,10 @@ define([ "jquery" ], function($) {
           .html(this.config.templates.empty)
     };
 
-    if (!$(this.config.el).is("textarea")) {
-      this.$el = $(this.config.el).attr("autocomplete", "off"), // turn off native browser autocomplete feature
-    }
+    this.$el = $(this.config.el);
+
+    // turn off native browser autocomplete feature unless it's textarea
+    !this.$el.is("textarea") && this.$el.attr("autocomplete", "off");
 
     this.init();
   }

--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -85,7 +85,9 @@ define([ "jquery" ], function($) {
           .html(this.config.templates.empty)
     };
 
-    this.$el = $(this.config.el).attr("autocomplete", "off"), // turn off native browser autocomplete feature
+    if (!$(this.config.el).is("textarea")) {
+      this.$el = $(this.config.el).attr("autocomplete", "off"), // turn off native browser autocomplete feature
+    }
 
     this.init();
   }


### PR DESCRIPTION
Android system keyboard uses attribute `autocomplete=off` to disable
autosuggestions / corrections. In normal text input fields this makes
sense, but textarea fields never _suffer_ from browser autocomplete
feature and mobile suggestions/corrections are very desired.

Related bug report on TT:
https://www.lonelyplanet.com/thorntree/forums/report-a-bug/topics/keyboard-functions-not-working-when-posting

We were able to reproduce the issue.