### PR TITLE
Fixing an error when the el is null

### DIFF
--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -52,6 +52,11 @@ define([ "jquery" ], function($) {
       },
     });
 
+    this.$el = $(this.config.el);
+    if (!this.$el.length) {
+      return;
+    }
+
     // make sure threshold isn't lower than 1
     this.config.threshold < 1 && (this.config.threshold = 1);
 
@@ -84,8 +89,6 @@ define([ "jquery" ], function($) {
           .addClass(this.classes.item.concat(" ", this.classes.empty, " ", this.classes.disabled))
           .html(this.config.templates.empty)
     };
-
-    this.$el = $(this.config.el);
 
     // turn off native browser autocomplete feature unless it's textarea
     !this.$el.is("textarea") && this.$el.attr("autocomplete", "off");

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grunt-template-jasmine-requirejs": "~0.1.10",
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-copy": "latest",
-    "jasmine-jquery": "~1.3.3",
+    "jasmine-jquery": "^2.1.1",
     "grunt-bump": "0.0.13"
   }
 }

--- a/spec/tests/autocomplete_spec.js
+++ b/spec/tests/autocomplete_spec.js
@@ -47,6 +47,12 @@ require([ "jquery", "autocomplete" ], function($, AutoComplete) {
         expect(instance.$el).toExist();
       });
 
+      it("should return if no element is selected", function() {
+        var instance = new AutoComplete({ el: ".js-foo" });
+
+        expect(instance).not.toExist();
+      });
+
       it("should have autocomplete='off' attribute", function() {
         expect(instance.$el).toHaveAttr("autocomplete", "off");
       });

--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -52,6 +52,11 @@ define([ "jquery" ], function($) {
       },
     });
 
+    this.$el = $(this.config.el);
+    if (!this.$el.length) {
+      return;
+    }
+
     // make sure threshold isn't lower than 1
     this.config.threshold < 1 && (this.config.threshold = 1);
 
@@ -84,8 +89,6 @@ define([ "jquery" ], function($) {
           .addClass(this.classes.item.concat(" ", this.classes.empty, " ", this.classes.disabled))
           .html(this.config.templates.empty)
     };
-
-    this.$el = $(this.config.el);
 
     // turn off native browser autocomplete feature unless it's textarea
     !this.$el.is("textarea") && this.$el.attr("autocomplete", "off");


### PR DESCRIPTION
For some reason, we're seeing every now and then that the `$el` is null, so it 'splodes trying to do the wrap method.

There is a bunch of work needed to get the Jasmine tests passing again too, but we can handle that later in another PR.